### PR TITLE
'ghq list -p' instead of '(ghq root)/(ghq list)'

### DIFF
--- a/dot.sh/ghq.sh
+++ b/dot.sh/ghq.sh
@@ -1,2 +1,2 @@
-alias ghqlist='cd $(ghq root)/$(ghq list | peco)'
+alias ghqlist='cd $(ghq list -p | peco)'
 alias ghqhub='hub browse $(ghq list | peco | cut -d "/" -f 2,3)'


### PR DESCRIPTION
`ghq list -p` provides the full path of repositories.
